### PR TITLE
Update scala_utils.py to handle empty strings in java_list_to_python_list

### DIFF
--- a/pydeequ/scala_utils.py
+++ b/pydeequ/scala_utils.py
@@ -98,7 +98,8 @@ def java_list_to_python_list(java_list:str, datatype):
     # Currently turn the java object into a string and pass it through
     start = java_list.index('(')
     end = java_list.index(')')
-    vals = [datatype(i) if i !="" else None for i in java_list[start+1:end].split(',')]
+    empty_val = '' if datatype == str else None
+    vals = [datatype(i) if i !='' else empty_val for i in java_list[start+1:end].split(',')]
     return vals
 
 # TODO Tuple => Python Tuple

--- a/pydeequ/scala_utils.py
+++ b/pydeequ/scala_utils.py
@@ -98,7 +98,7 @@ def java_list_to_python_list(java_list:str, datatype):
     # Currently turn the java object into a string and pass it through
     start = java_list.index('(')
     end = java_list.index(')')
-    vals = [datatype(i) for i in java_list[start+1:end].split(',')]
+    vals = [datatype(i) if i !="" else None for i in java_list[start+1:end].split(',')]
     return vals
 
 # TODO Tuple => Python Tuple


### PR DESCRIPTION
"handle empty values in scala_utils.py->java_list_to_python_list"

*Issue #, if available:*
https://github.com/awslabs/python-deequ/issues/12

*Description of changes:*
java_list_to_python_list attempts to convert java lists to python lists, however, it is not handling empty values correctly. For example when the java string is [''], attempting to create a float with float('') will fail. This change sets empty values to python None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
