### PR TITLE
Remove PySpark from install_requires dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ def setup_package():
             "Programming Language :: Python :: 3",
             "License :: OSI Approved :: Apache Software License"
         ],
-        install_requires=['pyspark==2.4.7', 'pandas'],
+        install_requires=['pandas'],
         setup_requires=['pyspark==2.4.7', 'pytest-runner', 'pandas'],
-        tests_require=['pyspark==2.4.7','pytest', 'pandas']
+        tests_require=['pyspark==2.4.7', 'pytest', 'pandas']
 
     )
 


### PR DESCRIPTION
This pull request fixes #13 by removing install-time dependency on PySpark. If PyDeequ package is installed on a Apache Spark compatible cluster, there's 100% confidence that PySpark module path is already there. Just Deequ JAR has to be installed directly from Maven Central - https://search.maven.org/artifact/com.amazon.deequ/deequ

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
