### PR TITLE
Add spark 3.3-compatible deequ maven coordinates

### DIFF
--- a/pydeequ/configs.py
+++ b/pydeequ/configs.py
@@ -5,6 +5,7 @@ import re
 
 
 SPARK_TO_DEEQU_COORD_MAPPING = {
+    "3.3": "com.amazon.deequ:deequ:2.0.3-spark-3.3",
     "3.2": "com.amazon.deequ:deequ:2.0.1-spark-3.2",
     "3.1": "com.amazon.deequ:deequ:2.0.0-spark-3.1",
     "3.0": "com.amazon.deequ:deequ:1.2.2-spark-3.0",


### PR DESCRIPTION
Add maven coordinates for deequ 2.0.3, spark 3.3


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
