### PR TITLE
chore: release 1.1.0rc0

### DIFF
--- a/pydeequ/__init__.py
+++ b/pydeequ/__init__.py
@@ -12,7 +12,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Placeholder docstrings"""
-__version__ = "1.0.1"
+__version__ = "1.1.0rc0"
 
 from pyspark.sql import SparkSession
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydeequ"
-version = "1.0.1"
+version = "1.1.0rc0"
 description = "PyDeequ - Unit Tests for Data"
 authors = ["Calvin Wang <calviwan@amazon.com>"]
 maintainers = ["Calvin Wang <calviwan@amazon.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.6.2,<4"
+python = ">=3.7,<4"
 numpy = ">=1.14.1"
 pandas = ">=0.23.0"
 pyspark = { version = ">=2.4.7, <3.3.0", optional = true }

--- a/tests/test_pydeequ.py
+++ b/tests/test_pydeequ.py
@@ -1,7 +1,0 @@
-# -*- coding: utf-8 -*-
-from pydeequ import __version__
-
-
-def test_version():
-    if __version__ != "1.0.1":
-        raise AssertionError


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/python-deequ/issues/106

*Description of changes:*

We will be doing release candidate first since we have not released for a quite while. 

*testing*:

- [x] CI should be green
- [x] versioning should be correct

```
In [1]: from pydeequ import __version__

In [2]: __version__
Out[2]: '1.1.0rc0'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
