### PR TITLE
fix: add assertion and hints for isContainedIn and hasPattern

### DIFF
--- a/pydeequ/check_functions.py
+++ b/pydeequ/check_functions.py
@@ -1,0 +1,2 @@
+def is_one(x):
+    return x == 1 / 1

--- a/pydeequ/checks.py
+++ b/pydeequ/checks.py
@@ -3,7 +3,9 @@ from enum import Enum
 
 from pyspark.sql import SparkSession
 
+from pydeequ.check_functions import is_one
 from pydeequ.scala_utils import ScalaFunction1, to_scala_seq
+
 
 # TODO implement custom assertions
 # TODO implement all methods without outside class dependencies
@@ -564,8 +566,10 @@ class Check:
         :param str hint: A hint that states why a constraint could have failed.
         :return: hasPattern self: A Check object that runs the condition on the column.
         """
-        assertion_func = ScalaFunction1(self._spark_session.sparkContext._gateway, assertion) if assertion \
-            else getattr(self._Check, "hasPattern$default$2")()
+        if not assertion:
+            assertion = is_one
+
+        assertion_func = ScalaFunction1(self._spark_session.sparkContext._gateway, assertion)
         name = self._jvm.scala.Option.apply(name)
         hint = self._jvm.scala.Option.apply(hint)
         pattern_regex = self._jvm.scala.util.matching.Regex(pattern, None)
@@ -779,19 +783,25 @@ class Check:
         self._Check = self._Check.isGreaterThanOrEqualTo(columnA, columnB, assertion_func, hint)
         return self
 
-    def isContainedIn(self, column, allowed_values):
+    def isContainedIn(self, column, allowed_values, assertion=None, hint=None):
         """
         Asserts that every non-null value in a column is contained in a set of predefined values
 
         :param str column: Column in DataFrame to run the assertion on.
         :param list[str] allowed_values: A function that accepts allowed values for the column.
+        :param lambda assertion: A function that accepts an int or float parameter.
         :param str hint: A hint that states why a constraint could have failed.
         :return: isContainedIn self: A Check object that runs the assertion on the columns.
         """
         arr = self._spark_session.sparkContext._gateway.new_array(self._jvm.java.lang.String, len(allowed_values))
         for i in range(len(allowed_values)):
             arr[i] = allowed_values[i]
-        self._Check = self._Check.isContainedIn(column, arr)
+
+        if not assertion:
+            assertion = is_one
+        assertion_func = ScalaFunction1(self._spark_session.sparkContext._gateway, assertion)
+        hint = self._jvm.scala.Option.apply(hint)
+        self._Check = self._Check.isContainedIn(column, arr, assertion_func, hint)
         return self
 
     def evaluate(self, context):


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/python-deequ/issues/142

*Description of changes:*

FIx #142. The constraint suggested comes Deequ and the isContainedIn method did not support `assertion` and `hint` parameters. This PR adds it back. 

In addition, we add the`is_one` check function and set it as default for hasPattern and isContainedIn function. This is consistent with the Deequ's default value for assertion, see https://github.com/awslabs/deequ/blob/d3dbe2d77563fdbe0acaadcf55bd84e5f688027f/src/main/scala/com/amazon/deequ/checks/Check.scala#L1084. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
