### PR TITLE
chore: upgrade Spark to 3.4, and Deequ to 2.0.5

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYSPARK_VERSION: ["3.0", "3.1.3", "3.2", "3.3"]
+        PYSPARK_VERSION: ["3.0", "3.1.3", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pydeequ/configs.py
+++ b/pydeequ/configs.py
@@ -5,6 +5,7 @@ import re
 
 
 SPARK_TO_DEEQU_COORD_MAPPING = {
+    "3.4": "com.amazon.deequ:deequ:2.0.5-spark-3.4",
     "3.3": "com.amazon.deequ:deequ:2.0.3-spark-3.3",
     "3.2": "com.amazon.deequ:deequ:2.0.1-spark-3.2",
     "3.1": "com.amazon.deequ:deequ:2.0.0-spark-3.1",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/python-deequ/issues/151

*Description of changes:*

Upgrade Spark to 3.4 and Deequ to 2.0.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
