### PR TITLE
added support to where method and tests

### DIFF
--- a/pydeequ/checks.py
+++ b/pydeequ/checks.py
@@ -116,6 +116,14 @@ class Check:
         self.constraints.append(constraint)
         self._Check = constraint._Check
 
+    def where(self, filter: str):
+        test = self._Check.getClass()
+        if self._Check.getClass().toString().endswith("CheckWithLastConstraintFilterable"):
+            self._Check = self._Check.where(filter)
+        else:
+            raise TypeError(f"Expected CheckWithLastConstraintFilterable class, not {self._Check.getClass()}")
+        return self
+
     def addFilterableContstraint(self, creationFunc):
         """Adds a constraint that can subsequently be replaced with a filtered version
         :param creationFunc:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/python-deequ/issues/158
*Description of changes:*
Added where method, the requirement to use it with the current setup is to make sure that the Check is represented by its child class CheckWithLastConstraintFilterable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
