### PR TITLE
Feature/support where filter

### DIFF
--- a/pydeequ/checks.py
+++ b/pydeequ/checks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from enum import Enum
 
+from py4j.protocol import Py4JError
 from pyspark.sql import SparkSession
 
 from pydeequ.check_functions import is_one
@@ -117,11 +118,10 @@ class Check:
         self._Check = constraint._Check
 
     def where(self, filter: str):
-        is_filterable = self._jvm.py4j.reflection.TypeUtil.isInstanceOf(
-            "com.amazon.deequ.checks.CheckWithLastConstraintFilterable", self._Check)
-        if not is_filterable:
-            raise TypeError(f"Expected class CheckWithLastConstraintFilterable, not {self._Check.getClass()}")
-        self._Check = self._Check.where(filter)
+        try:
+            self._Check = self._Check.where(filter)
+        except Py4JError:
+            raise TypeError(f"Method doesn't exist in {self._Check.getClass()}, class has to be filterable")
         return self
 
     def addFilterableContstraint(self, creationFunc):

--- a/pydeequ/checks.py
+++ b/pydeequ/checks.py
@@ -116,6 +116,14 @@ class Check:
         self.constraints.append(constraint)
         self._Check = constraint._Check
 
+    def where(self, filter: str):
+        test = self._Check.getClass()
+        if self._Check.getClass().toString().endswith("CheckWithLastConstraintFilterable"):
+            self._Check = self._Check.where(filter)
+        else:
+            raise TypeError(f"Expected CheckWithLastConstraintFilterable class, not {self._Check.getClass()}")
+        return self
+
     def addFilterableContstraint(self, creationFunc):
         """Adds a constraint that can subsequently be replaced with a filtered version
         :param creationFunc:

--- a/pydeequ/checks.py
+++ b/pydeequ/checks.py
@@ -117,11 +117,11 @@ class Check:
         self._Check = constraint._Check
 
     def where(self, filter: str):
-        test = self._Check.getClass()
-        if self._Check.getClass().toString().endswith("CheckWithLastConstraintFilterable"):
-            self._Check = self._Check.where(filter)
-        else:
-            raise TypeError(f"Expected CheckWithLastConstraintFilterable class, not {self._Check.getClass()}")
+        is_filterable = self._jvm.py4j.reflection.TypeUtil.isInstanceOf(
+            "com.amazon.deequ.checks.CheckWithLastConstraintFilterable", self._Check)
+        if not is_filterable:
+            raise TypeError(f"Expected class CheckWithLastConstraintFilterable, not {self._Check.getClass()}")
+        self._Check = self._Check.where(filter)
         return self
 
     def addFilterableContstraint(self, creationFunc):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1262,9 +1262,6 @@ class TestChecks(unittest.TestCase):
             self.where(lambda x: x == 2.0, "ssn='000-00-0000'", "column 'ssn' has one value 000-00-0000"),
             [Row(constraint_status="Failure")],
         )
-        self.assertRaises(Check(self.spark, CheckLevel.Warning, "test where").kllSketchSatisfies(
-            "b", lambda x: x.parameters().apply(0) == 1.0, KLLParameters(self.spark, 2, 0.64, 2)
-        ).where("d=5"), TypeError)
         check = Check(self.spark, CheckLevel.Warning, "test where").hasMin("f", lambda x: x == 2, "The f has min value 2 becasue of the additional filter").where('f>=2')
         result = VerificationSuite(self.spark).onData(self.df).addCheck(check.isGreaterThan("e", "h", lambda x: x == 1, "Column H is not smaller than Column E")).run()
         df = VerificationResult.checkResultsAsDataFrame(self.spark, result)
@@ -1272,6 +1269,10 @@ class TestChecks(unittest.TestCase):
             df.select("constraint_status").collect(),
             [Row(constraint_status="Success"), Row(constraint_status="Failure")],
         )
+        with self.assertRaises(TypeError):
+            Check(self.spark, CheckLevel.Warning, "test where").kllSketchSatisfies(
+                "b", lambda x: x.parameters().apply(0) == 1.0, KLLParameters(self.spark, 2, 0.64, 2)
+            ).where("d=5")
 
     @pytest.mark.xfail(reason="@unittest.expectedFailure")
     def test_fail_where(self):


### PR DESCRIPTION
*Issue #, if available:*
[158](https://github.com/awslabs/python-deequ/issues/158)
*Description of changes:*
Added support for the `.where` method, which in Scala is implemented in the `CheckWithLastConstranitFilterable` class. The idea is to check that the `_Check` attribute is an instance of this class and only then allow the `.where` method to be applied.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
