### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/pydeequ/__init__.py
+++ b/pydeequ/__init__.py
@@ -12,7 +12,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Placeholder docstrings"""
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 from pyspark.sql import SparkSession
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
 name = "pydeequ"
-version = "1.1.1"
+version = "1.2.0"
 description = "PyDeequ - Unit Tests for Data"
-authors = ["Calvin Wang <calviwan@amazon.com>"]
-maintainers = ["Calvin Wang <calviwan@amazon.com>"]
+authors = ["Calvin Wang <calviwan@amazon.com>", "Chenyang Liu <peterl@amazon.com>"]
+maintainers = ["Calvin Wang <calviwan@amazon.com>", "Chenyang Liu <peterl@amazon.com>"]
 license = "Apache-2.0"
 readme = "README.md"
 homepage = "https://pydeequ.readthedocs.io"


### PR DESCRIPTION
*Issue #, if available:* N/A, chore release

*Description of changes:*
Release those changes https://github.com/awslabs/python-deequ/compare/04e26342ace80ab33de32a6d89d4676a5d336aa9...release/1_2_0
- feat: support where filter https://github.com/awslabs/python-deequ/pull/176 
- fix: add assertion and hints for isContainedIn and hasPattern; Add is_one and use as default assertion (https://github.com/awslabs/python-deequ/pull/157)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
