### PR TITLE
upgrade to 3.4 and fix interface changes

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYSPARK_VERSION: ["3.0", "3.1.3", "3.2", "3.3"]
+        PYSPARK_VERSION: ["3.0", "3.1.3", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYSPARK_VERSION: ["3.0", "3.1.3", "3.2", "3.3", "3.4"]
+        PYSPARK_VERSION: ["3.4"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pydeequ/checks.py
+++ b/pydeequ/checks.py
@@ -5,7 +5,7 @@ from py4j.protocol import Py4JError
 from pyspark.sql import SparkSession
 
 from pydeequ.check_functions import is_one
-from pydeequ.scala_utils import ScalaFunction1, to_scala_seq
+from pydeequ.scala_utils import ScalaFunction1, to_scala_seq, to_scala_list
 
 
 # TODO implement custom assertions
@@ -406,7 +406,7 @@ class Check:
         self._Check = self._Check.hasApproxQuantile(column, float(quantile), assertion_func, hint)
         return self
 
-    def hasMinLength(self, column, assertion, hint=None):
+    def hasMinLength(self, column, assertion, hint=None, analyzerOptions=None):
         """
         Creates a constraint that asserts on the minimum length of a string datatype column.
 
@@ -418,10 +418,11 @@ class Check:
         """
         assertion_func = ScalaFunction1(self._spark_session.sparkContext._gateway, assertion)
         hint = self._jvm.scala.Option.apply(hint)
-        self._Check = self._Check.hasMinLength(column, assertion_func, hint)
+        analyzerOptions = self._jvm.scala.Option.apply(analyzerOptions)
+        self._Check = self._Check.hasMinLength(column, assertion_func, hint, analyzerOptions)
         return self
 
-    def hasMaxLength(self, column, assertion, hint=None):
+    def hasMaxLength(self, column, assertion, hint=None, analyzerOptions=None):
         """
         Creates a constraint that asserts on the maximum length of a string datatype column
 
@@ -433,7 +434,8 @@ class Check:
         """
         assertion_func = ScalaFunction1(self._spark_session.sparkContext._gateway, assertion)
         hint = self._jvm.scala.Option.apply(hint)
-        self._Check = self._Check.hasMaxLength(column, assertion_func, hint)
+        analyzerOptions = self._jvm.scala.Option.apply(analyzerOptions)
+        self._Check = self._Check.hasMaxLength(column, assertion_func, hint, analyzerOptions)
         return self
 
     def hasMin(self, column, assertion, hint=None):
@@ -539,7 +541,12 @@ class Check:
         self._Check = self._Check.hasCorrelation(columnA, columnB, assertion_func, hint)
         return self
 
-    def satisfies(self, columnCondition, constraintName, assertion=None, hint=None):
+    def satisfies(self,
+                  columnCondition,
+                  constraintName,
+                  assertion=None,
+                  hint=None,
+                  columns=[]):
         """
         Creates a constraint that runs the given condition on the data frame.
 
@@ -558,7 +565,8 @@ class Check:
             else getattr(self._Check, "satisfies$default$2")()
         )
         hint = self._jvm.scala.Option.apply(hint)
-        self._Check = self._Check.satisfies(columnCondition, constraintName, assertion_func, hint)
+        columns = to_scala_list(self._jvm, columns)
+        self._Check = self._Check.satisfies(columnCondition, constraintName, assertion_func, hint, columns)
         return self
 
     def hasPattern(self, column, pattern, assertion=None, name=None, hint=None):

--- a/pydeequ/configs.py
+++ b/pydeequ/configs.py
@@ -5,6 +5,7 @@ import re
 
 
 SPARK_TO_DEEQU_COORD_MAPPING = {
+    "3.4": "com.amazon.deequ:deequ:2.0.6-spark-3.4",
     "3.3": "com.amazon.deequ:deequ:2.0.3-spark-3.3",
     "3.2": "com.amazon.deequ:deequ:2.0.1-spark-3.2",
     "3.1": "com.amazon.deequ:deequ:2.0.0-spark-3.1",

--- a/pydeequ/configs.py
+++ b/pydeequ/configs.py
@@ -6,11 +6,6 @@ import re
 
 SPARK_TO_DEEQU_COORD_MAPPING = {
     "3.4": "com.amazon.deequ:deequ:2.0.6-spark-3.4",
-    "3.3": "com.amazon.deequ:deequ:2.0.3-spark-3.3",
-    "3.2": "com.amazon.deequ:deequ:2.0.1-spark-3.2",
-    "3.1": "com.amazon.deequ:deequ:2.0.0-spark-3.1",
-    "3.0": "com.amazon.deequ:deequ:1.2.2-spark-3.0",
-    "2.4": "com.amazon.deequ:deequ:1.1.0_spark-2.4-scala-2.11",
 }
 
 

--- a/pydeequ/profiles.py
+++ b/pydeequ/profiles.py
@@ -242,6 +242,7 @@ class ColumnProfilesBuilder:
         self.columnProfileClasses = {
             "StandardColumnProfile": StandardColumnProfile,
             "NumericColumnProfile": NumericColumnProfile,
+            "StringColumnProfile": StringColumnProfile,
         }
 
     def _columnProfilesFromColumnRunBuilderRun(self, run):
@@ -400,6 +401,56 @@ class StandardColumnProfile(ColumnProfile):
         :return: A JSON of the standard profiles
         """
         return f"StandardProfiles for column: {self.column}: {json.dumps(self.all, indent=4)}"
+
+
+class StringColumnProfile(ColumnProfile):
+    """
+    String Column Profile class
+
+    :param SparkSession spark_session: sparkSession
+    :param column: the designated column of which the profile is run on
+    :param java_column_profile: The profile mapped as a Java map
+    """
+    def __init__(self, spark_session: SparkSession, column, java_column_profile):
+        super().__init__(spark_session, column, java_column_profile)
+        self._minLength = get_or_else_none(java_column_profile.minLength())
+        self._maxLength = get_or_else_none(java_column_profile.maxLength())
+        self.all = {
+            "completeness": self.completeness,
+            "approximateNumDistinctValues": self.approximateNumDistinctValues,
+            "dataType": self.dataType,
+            "isDataTypeInferred": self.isDataTypeInferred,
+            "typeCounts": self.typeCounts,
+            "histogram": self.histogram,
+            "minLength": self._minLength,
+            "maxLength": self._maxLength,
+        }
+
+    def __str__(self):
+        """
+        A JSON of the standard profiles for each column
+
+        :return: A JSON of the standard profiles
+        """
+        return f"StringProfiles for column: {self.column}: {json.dumps(self.all, indent=4)}"
+
+    @property
+    def maxLength(self):
+        """
+        A getter for the maximum length of the string column
+
+        :return: gets the maximum length of the column
+        """
+        return self._maxLength
+
+    @property
+    def minLength(self):
+        """
+        A getter for the maximum length of the string column
+
+        :return: gets the maximum length of the column
+        """
+        return self._minLength
 
 
 class NumericColumnProfile(ColumnProfile):

--- a/pydeequ/scala_utils.py
+++ b/pydeequ/scala_utils.py
@@ -80,6 +80,18 @@ def to_scala_seq(jvm, iterable):
     return jvm.scala.collection.JavaConversions.iterableAsScalaIterable(iterable).toSeq()
 
 
+def to_scala_list(jvm, iterable):
+    """
+    Helper method to take an iterable and turn it into a Scala list
+    Args:
+        jvm: Spark session's JVM
+        iterable: your iterable
+    Returns:
+        Scala list
+    """
+    return jvm.scala.collection.JavaConversions.iterableAsScalaIterable(iterable).toList()
+
+
 def to_scala_map(spark_session, d):
     """
     Convert a dict into a JVM Map.

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -90,8 +90,10 @@ class TestAnalyzers(unittest.TestCase):
         self.assertEqual(df_from_json.select("value").collect(), result_df.select("value").collect())
         return result_df.select("value").collect()
 
-    def Compliance(self, instance, predicate, where=None):
-        result = self.AnalysisRunner.onData(self.df).addAnalyzer(Compliance(instance, predicate, where)).run()
+    def Compliance(self, instance, predicate, where=None, columns=[]):
+        result = (
+            self.AnalysisRunner.onData(self.df).addAnalyzer(Compliance(instance, predicate, where, columns)).run()
+        )
         result_df = AnalyzerContext.successMetricsAsDataFrame(self.spark, result)
         result_json = AnalyzerContext.successMetricsAsJson(self.spark, result)
         df_from_json = self.spark.read.json(self.sc.parallelize([result_json]))


### PR DESCRIPTION
> Note: Can we create a separate branch for this change to merge into? The changes are only compatible with scala-deequ version `>=2.0.4`  and not backward compatible. It will look fractional if we make it work universally since for the same class both new and old interfaces need to be invoked.

*Issue #, if available:*

https://github.com/awslabs/python-deequ/issues/148

Forward compatibility issue for scala deequ version >=2.0.4. 

*Description of changes:*

Update the invocation code according to the change of the Scala "deequ-2.0.6-spark-3.4" version interfaces

The interface changes include
- Analyzer class 
  - Compliance
  - Histogram
  - MaxLength
  - MinLength
  - Mean
- Check methods
  - hasMaxLength
  - hasMinLength
  - satisfy

Logic change
- prioritize StringColumnProfile over StandardColumnProfile


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
