### PR TITLE
Resolve AttributeError: 'ScalaFunction1' object has no attribute 'hashCode'.

### DIFF
--- a/pydeequ/scala_utils.py
+++ b/pydeequ/scala_utils.py
@@ -37,6 +37,9 @@ class ScalaFunction1(PythonCallback):
         """Implements the apply function"""
         return self.lambda_function(arg)
 
+    def hashCode(self):
+        return hash(self.lambda_function)
+
     class Java:
         """scala.Function1: a function that takes one argument"""
 
@@ -54,6 +57,9 @@ class ScalaFunction2(PythonCallback):
     def apply(self, t1, t2):
         """Implements the apply function"""
         return self.lambda_function(t1, t2)
+
+    def hashCode(self):
+        return hash(self.lambda_function)
 
     class Java:
         """scala.Function2: a function that takes two arguments"""

--- a/pydeequ/scala_utils.py
+++ b/pydeequ/scala_utils.py
@@ -38,7 +38,7 @@ class ScalaFunction1(PythonCallback):
         return self.lambda_function(arg)
 
     def hashCode(self):
-        return hash(self.lambda_function)
+        return self.gateway.jvm.java.lang.Integer.valueOf(hash(self.lambda_function))
 
     class Java:
         """scala.Function1: a function that takes one argument"""
@@ -59,7 +59,7 @@ class ScalaFunction2(PythonCallback):
         return self.lambda_function(t1, t2)
 
     def hashCode(self):
-        return hash(self.lambda_function)
+        return self.gateway.jvm.java.lang.Integer.valueOf(hash(self.lambda_function))
 
     class Java:
         """scala.Function2: a function that takes two arguments"""

--- a/pydeequ/scala_utils.py
+++ b/pydeequ/scala_utils.py
@@ -38,7 +38,7 @@ class ScalaFunction1(PythonCallback):
         return self.lambda_function(arg)
 
     def hashCode(self):
-        return self.gateway.jvm.java.lang.Integer.valueOf(hash(self.lambda_function))
+        return self.gateway.jvm.java.lang.Integer.hashCode(hash(self.lambda_function))
 
     class Java:
         """scala.Function1: a function that takes one argument"""
@@ -59,7 +59,7 @@ class ScalaFunction2(PythonCallback):
         return self.lambda_function(t1, t2)
 
     def hashCode(self):
-        return self.gateway.jvm.java.lang.Integer.valueOf(hash(self.lambda_function))
+        return self.gateway.jvm.java.lang.Integer.hashCode(hash(self.lambda_function))
 
     class Java:
         """scala.Function2: a function that takes two arguments"""

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1367,3 +1367,24 @@ class TestChecks(unittest.TestCase):
 
         df = VerificationResult.checkResultsAsDataFrame(self.spark, result)
         self.assertEqual(df.select("constraint_status").collect(), [Row(constraint_status="Success"), Row(constraint_status="Success")])
+
+    def test_hash_code(self):
+        """
+        Lack of Exception is passing.  Previously this test would fail with:
+        AttributeError: 'ScalaFunction1' object has no attribute 'hashCode'
+        """
+        vrb = VerificationSuite(self.spark) \
+            .onData(self.df)
+        check = Check(self.spark, CheckLevel.Error, "Enough checks to trigger a hashCode not an attribute of ScalaFunction1")
+        check.isComplete('b')
+        vrb.addCheck(check)
+        check.containsEmail('email')
+        vrb.addCheck(check)
+        check.isGreaterThanOrEqualTo("d", "b")
+        vrb.addCheck(check)
+        check.isLessThanOrEqualTo("b", "d")
+        vrb.addCheck(check)
+        check.hasDataType("d", ConstrainableDataTypes.String, lambda x: x >= 1)
+        vrb.addCheck(check)
+
+        result = vrb.run()

--- a/tests/test_scala_utils.py
+++ b/tests/test_scala_utils.py
@@ -25,12 +25,23 @@ class TestScalaUtils(unittest.TestCase):
         self.assertFalse(notNoneTest.apply(None))
         self.assertTrue(notNoneTest.apply("foo"))
 
+        # Test hashCode()
+        self.assertNotEqual(greaterThan10.hashCode(), notNoneTest.hashCode())
+        self.assertTrue(isinstance(greaterThan10.hashCode(), int))
+
         appendTest = ScalaFunction1(self.sc._gateway, "{}test".format)
         self.assertEqual("xtest", appendTest.apply("x"))
 
     def test_scala_function2(self):
-        concatFunction = ScalaFunction2(self.sc._gateway, lambda x, y: x + y)
+        lambda_func = lambda x, y: x + y
+        concatFunction = ScalaFunction2(self.sc._gateway, lambda_func)
         self.assertEqual("ab", concatFunction.apply("a", "b"))
+
+        anotherConcatFunction = ScalaFunction2(self.sc._gateway, lambda_func)
+
+        # Test hashCode()
+        self.assertEqual(concatFunction.hashCode(), anotherConcatFunction.hashCode())
+        self.assertTrue(isinstance(concatFunction.hashCode(), int))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Issue #, if available:*
#91 

*Description of changes:*
Added `hashCode()` method to `ScalaFunction1` and `ScalaFunction2`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
