### PR TITLE
Upgrade Deequ to 2.0.8

### DIFF
--- a/pydeequ/configs.py
+++ b/pydeequ/configs.py
@@ -5,10 +5,10 @@ import re
 
 
 SPARK_TO_DEEQU_COORD_MAPPING = {
-    "3.5": "com.amazon.deequ:deequ:2.0.7-spark-3.5",
-    "3.3": "com.amazon.deequ:deequ:2.0.7-spark-3.3",
-    "3.2": "com.amazon.deequ:deequ:2.0.7-spark-3.2",
-    "3.1": "com.amazon.deequ:deequ:2.0.7-spark-3.1"
+    "3.5": "com.amazon.deequ:deequ:2.0.8-spark-3.5",
+    "3.3": "com.amazon.deequ:deequ:2.0.8-spark-3.3",
+    "3.2": "com.amazon.deequ:deequ:2.0.8-spark-3.2",
+    "3.1": "com.amazon.deequ:deequ:2.0.8-spark-3.1"
 }
 
 

--- a/pydeequ/suggestions.py
+++ b/pydeequ/suggestions.py
@@ -229,8 +229,11 @@ class FractionalCategoricalRangeRule(_RulesObject):
         default_category_sorter = scala_get_default_argument(
             self._deequSuggestions.rules.FractionalCategoricalRangeRule, 2
         )
+        default_interval_strategy = scala_get_default_argument(
+            self._deequSuggestions.rules.FractionalCategoricalRangeRule, 3
+        )
         return self._deequSuggestions.rules.FractionalCategoricalRangeRule(
-            self.targetDataCoverageFraction, default_category_sorter
+            self.targetDataCoverageFraction, default_category_sorter, default_interval_strategy
         )
 
 
@@ -252,7 +255,19 @@ class RetainCompletenessRule(_RulesObject):
 
     @property
     def rule_jvm(self):
-        return self._deequSuggestions.rules.RetainCompletenessRule()
+        default_min_completeness = scala_get_default_argument(
+            self._deequSuggestions.rules.RetainCompletenessRule, 1
+        )
+        default_max_completeness = scala_get_default_argument(
+            self._deequSuggestions.rules.RetainCompletenessRule, 2
+        )
+        default_interval_strategy = scala_get_default_argument(
+            self._deequSuggestions.rules.RetainCompletenessRule, 3
+        )
+
+        return self._deequSuggestions.rules.RetainCompletenessRule(
+            default_min_completeness, default_max_completeness, default_interval_strategy
+        )
 
 
 class RetainTypeRule(_RulesObject):


### PR DESCRIPTION
*Description of changes:*

- This version introduces default parameters for certain classes in Deequ, which breaks PyDeequ.
- As part of this change, we pass in the default value for these parameters at the time of constructing these classes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
