### PR TITLE
Issue #243 - Add CustomSql analyzer

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -16,6 +16,7 @@ Here are the current supported functionalities of Analyzers.
 | Compliance | Compliance(instance, predicate) | Done|
 | Correlation | Correlation(column1, column2) | Done| 
 | CountDistinct | CountDistinct(columns) | Done| 
+| CustomSql | CustomSql(expression, disambiguator) | Done| 
 | Datatype | Datatype(column) | Done| 
 | Distinctness | Distinctness(columns) | Done| 
 | Entropy | Entropy(column) | Done| 

--- a/pydeequ/analyzers.py
+++ b/pydeequ/analyzers.py
@@ -360,6 +360,30 @@ class CountDistinct(_AnalyzerObject):
         return self._deequAnalyzers.CountDistinct(to_scala_seq(self._jvm, self.columns))
 
 
+class CustomSql(_AnalyzerObject):
+    """
+    A custom SQL-based analyzer executing provided SQL expression.
+    The expression must return a single value.
+
+    :param str expression: A SQL expression to execute.
+    :param str where: A label used to distinguish this metric 
+        when running multiple custom SQL analyzers. Defaults to "*".
+    """
+
+    def __init__(self, expression: str, disambiguator: str = "*"):
+        self.expression = expression
+        self.disambiguator = disambiguator
+
+    @property
+    def _analyzer_jvm(self):
+        """
+        Returns the result of SQL expression execution.
+
+        :return self
+        """
+        return self._deequAnalyzers.CustomSql(self.expression, self.disambiguator)
+
+
 class DataType(_AnalyzerObject):
     """
     Data Type Analyzer. Returns the datatypes of column

--- a/pydeequ/analyzers.py
+++ b/pydeequ/analyzers.py
@@ -366,7 +366,7 @@ class CustomSql(_AnalyzerObject):
     The expression must return a single value.
 
     :param str expression: A SQL expression to execute.
-    :param str where: A label used to distinguish this metric 
+    :param str disambiguator: A label used to distinguish this metric 
         when running multiple custom SQL analyzers. Defaults to "*".
     """
 

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -3,7 +3,6 @@ import unittest
 
 import pytest
 from pyspark.sql import Row
-from pyspark.errors import AnalysisException
 
 from pydeequ import PyDeequSession
 from pydeequ.analyzers import (
@@ -326,8 +325,7 @@ class TestAnalyzers(unittest.TestCase):
 
     @pytest.mark.xfail(reason="@unittest.expectedFailure")
     def test_fail_CustomSql_incorrect_query(self):
-        with self.assertRaises(AnalysisException):
-            self.CustomSql("SELECT SUM(b)")
+        self.CustomSql("SELECT SUM(b)")
 
     def test_DataType(self):
         self.assertEqual(

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -14,6 +14,7 @@ from pydeequ.analyzers import (
     Compliance,
     Correlation,
     CountDistinct,
+    CustomSql,
     DataType,
     Distinctness,
     Entropy,
@@ -106,6 +107,14 @@ class TestAnalyzers(unittest.TestCase):
 
     def CountDistinct(self, columns):
         result = self.AnalysisRunner.onData(self.df).addAnalyzer(CountDistinct(columns)).run()
+        result_df = AnalyzerContext.successMetricsAsDataFrame(self.spark, result)
+        result_json = AnalyzerContext.successMetricsAsJson(self.spark, result)
+        df_from_json = self.spark.read.json(self.sc.parallelize([result_json]))
+        self.assertEqual(df_from_json.select("value").collect(), result_df.select("value").collect())
+        return result_df.select("value").collect()
+    
+    def CustomSql(self, expression, disambiguator="*"):
+        result = self.AnalysisRunner.onData(self.df).addAnalyzer(CustomSql(expression, disambiguator)).run()
         result_df = AnalyzerContext.successMetricsAsDataFrame(self.spark, result)
         result_json = AnalyzerContext.successMetricsAsJson(self.spark, result)
         df_from_json = self.spark.read.json(self.sc.parallelize([result_json]))
@@ -297,6 +306,16 @@ class TestAnalyzers(unittest.TestCase):
     @pytest.mark.xfail(reason="@unittest.expectedFailure")
     def test_fail_CountDistinct(self):
         self.assertEqual(self.CountDistinct("b"), [Row(value=1.0)])
+
+    def test_CustomSql(self):
+        self.df.createOrReplaceTempView("input_table")
+        self.assertEqual(self.CustomSql("SELECT SUM(b) FROM input_table"), [Row(value=6.0)])
+        self.assertEqual(self.CustomSql("SELECT AVG(LENGTH(a)) FROM input_table"), [Row(value=3.0)])
+        self.assertEqual(self.CustomSql("SELECT MAX(c) FROM input_table"), [Row(value=6.0)])
+
+    @pytest.mark.xfail(reason="@unittest.expectedFailure")
+    def test_fail_CustomSql(self):
+        self.assertEqual(self.CustomSql("SELECT SUM(b) FROM input_table"), [Row(value=1.0)])
 
     def test_DataType(self):
         self.assertEqual(


### PR DESCRIPTION
*Issue #, if available:*
#243 

*Description of changes:*
Add a Python wrapper for the existing CustomSql analyzer from the Scala implementation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
