### PR TITLE
Profiler: expose numRecords from the run result

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -20,5 +20,6 @@ Here are the current supported functionalities of Profiles.
 |  | useSparkSession |  |
 | ColumnProfilesBuilder | ColumnProfilesBuilder(spark_session) | Done |
 |  | property: profiles | Done |
+|  | property: numRecords | Done |
 | StandardColumnProfile | StandardColumnProfile(spark_session, column, java_column_profile) | Done |
 | NumericColumnProfile | NumericColumnProfile(spark_session, column, java_column_profile) | Done |

--- a/pydeequ/profiles.py
+++ b/pydeequ/profiles.py
@@ -273,7 +273,7 @@ class ColumnProfilesBuilder:
         """
         A getter for the number of records
 
-        :return Optional[int]: number of records
+        :return int: number of records
         """
         return self._numRecords
 

--- a/pydeequ/profiles.py
+++ b/pydeequ/profiles.py
@@ -2,7 +2,6 @@
 """ Profiles file for all the Profiles classes in Deequ"""
 import json
 from collections import namedtuple
-from typing import Optional
 
 from pyspark.sql import DataFrame, SparkSession
 from pydeequ.analyzers import KLLParameters
@@ -239,7 +238,7 @@ class ColumnProfilesBuilder:
         self._sc = spark_session.sparkContext
         self._jvm = spark_session._jvm
         self._profiles = []
-        self._numRecords = None
+        self._numRecords = 0
         self.columnProfileClasses = {
             "StandardColumnProfile": StandardColumnProfile,
             "StringColumnProfile": StandardColumnProfile,
@@ -270,7 +269,7 @@ class ColumnProfilesBuilder:
         return self._profiles
 
     @property
-    def numRecords(self) -> Optional[int]:
+    def numRecords(self) -> int:
         """
         A getter for the number of records
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -72,6 +72,10 @@ class TestProfiles(unittest.TestCase):
         except TypeError:
             pass
 
+    def test_profile_numRecords(self):
+        result = ColumnProfilerRunner(self.spark).onData(self.df).run()
+        self.assertEqual(result.numRecords, 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tutorials/profiles.ipynb
+++ b/tutorials/profiles.ipynb
@@ -953,6 +953,21 @@
    ]
   },
   {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "print(result.numRecords)",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3010972\n"
+     ]
+    }
+   ],
+   "execution_count": 6
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
*Issue #, if available:*
#245

*Description of changes:*
Exposing the number of profiled records as `numRecords` property of the `ColumnProfilesBuilder` class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
