### PR TITLE
Profiler: add StringColumnProfile

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -22,4 +22,5 @@ Here are the current supported functionalities of Profiles.
 |  | property: profiles | Done |
 |  | property: numRecords | Done |
 | StandardColumnProfile | StandardColumnProfile(spark_session, column, java_column_profile) | Done |
+| StringColumnProfile | StringColumnProfile(spark_session, column, java_column_profile) | Done |
 | NumericColumnProfile | NumericColumnProfile(spark_session, column, java_column_profile) | Done |

--- a/pydeequ/profiles.py
+++ b/pydeequ/profiles.py
@@ -544,12 +544,16 @@ class StringColumnProfile(StandardColumnProfile):
         super().__init__(spark_session, column, java_column_profile)
         self._minLength = get_or_else_none(java_column_profile.minLength())
         self._maxLength = get_or_else_none(java_column_profile.maxLength())
-        self.all.update(
-            {
-                "minLength": self._minLength,
-                "maxLength": self._maxLength,
-            }
-        )
+        self.all = {
+            "completeness": self.completeness,
+            "approximateNumDistinctValues": self.approximateNumDistinctValues,
+            "dataType": self.dataType,
+            "isDataTypeInferred": self.isDataTypeInferred,
+            "typeCounts": self.typeCounts,
+            "histogram": self.histogram,
+            "minLength": self._minLength,
+            "maxLength": self._maxLength,
+        }
 
     @property
     def minLength(self) -> Optional[int]:

--- a/pydeequ/profiles.py
+++ b/pydeequ/profiles.py
@@ -2,7 +2,9 @@
 """ Profiles file for all the Profiles classes in Deequ"""
 import json
 from collections import namedtuple
+from typing import Optional
 
+from py4j.java_gateway import JavaObject
 from pyspark.sql import DataFrame, SparkSession
 from pydeequ.analyzers import KLLParameters
 from pydeequ.metrics import BucketDistribution
@@ -241,9 +243,8 @@ class ColumnProfilesBuilder:
         self._numRecords = 0
         self.columnProfileClasses = {
             "StandardColumnProfile": StandardColumnProfile,
-            "StringColumnProfile": StandardColumnProfile,
+            "StringColumnProfile": StringColumnProfile,
             "NumericColumnProfile": NumericColumnProfile,
-
         }
 
     def _columnProfilesFromColumnRunBuilderRun(self, run):
@@ -528,3 +529,36 @@ class NumericColumnProfile(ColumnProfile):
         """
         return self._approxPercentiles
 
+
+class StringColumnProfile(StandardColumnProfile):
+    """
+    String Column Profile class
+
+    :param SparkSession spark_session: sparkSession
+    :param str column: the designated column of which the profile is run on
+    :param JavaObject java_column_profile: The profile mapped as a Java map
+    """
+
+    def __init__(
+        self, spark_session: SparkSession, column: str, java_column_profile: JavaObject
+    ) -> None:
+        super().__init__(spark_session, column, java_column_profile)
+        self._minLength = get_or_else_none(java_column_profile.minLength())
+        self._maxLength = get_or_else_none(java_column_profile.maxLength())
+        self.all.update(
+            {
+                "minLength": self._minLength,
+                "maxLength": self._maxLength,
+            }
+        )
+
+    @property
+    def minLength(self) -> Optional[int]:
+        return self._minLength
+
+    @property
+    def maxLength(self) -> Optional[int]:
+        return self._maxLength
+
+    def __str__(self) -> str:
+        return f"StringProfiles for column: {self.column}: {json.dumps(self.all, indent=4)}"

--- a/pydeequ/profiles.py
+++ b/pydeequ/profiles.py
@@ -4,7 +4,6 @@ import json
 from collections import namedtuple
 from typing import Optional
 
-from py4j.java_gateway import JavaObject
 from pyspark.sql import DataFrame, SparkSession
 from pydeequ.analyzers import KLLParameters
 from pydeequ.metrics import BucketDistribution
@@ -540,7 +539,7 @@ class StringColumnProfile(StandardColumnProfile):
     """
 
     def __init__(
-        self, spark_session: SparkSession, column: str, java_column_profile: JavaObject
+        self, spark_session: SparkSession, column: str, java_column_profile
     ) -> None:
         super().__init__(spark_session, column, java_column_profile)
         self._minLength = get_or_else_none(java_column_profile.minLength())

--- a/pydeequ/profiles.py
+++ b/pydeequ/profiles.py
@@ -529,7 +529,7 @@ class NumericColumnProfile(ColumnProfile):
         return self._approxPercentiles
 
 
-class StringColumnProfile(StandardColumnProfile):
+class StringColumnProfile(ColumnProfile):
     """
     String Column Profile class
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -86,14 +86,17 @@ class TestProfiles(unittest.TestCase):
         self.assertEqual(column_profile.approximateNumDistinctValues, 3)
         self.assertEqual(column_profile.typeCounts["String"], 3)
         self.assertEqual(column_profile.isDataTypeInferred, False)
-        self.assertListEqual(
-            sorted(column_profile.histogram),
-            [
-                DistributionValue("bar", 1, 1/3),
-                DistributionValue("bazz", 1, 1/3),
-                DistributionValue("foo", 1, 1/3),
-            ]
-        )
+        actual_histogram = sorted(column_profile.histogram, key=lambda x: x.value)
+        self.assertEqual(len(actual_histogram), 3)
+        expected_histogram = [
+            DistributionValue("bar", 1, 1 / 3),
+            DistributionValue("bazz", 1, 1 / 3),
+            DistributionValue("foo", 1, 1 / 3),
+        ]
+        for actual, expected in zip(actual_histogram, expected_histogram):
+            self.assertEqual(actual.value, expected.value)
+            self.assertEqual(actual.count, expected.count)
+            self.assertAlmostEquals(actual.ratio, expected.ratio)
 
 
 if __name__ == "__main__":

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -82,6 +82,7 @@ class TestProfiles(unittest.TestCase):
         self.assertEqual(column_profile.minLength, 3)
         self.assertEqual(column_profile.maxLength, 4)
         self.assertEqual(str(column_profile)[0:29], "StringProfiles for column: a:")
+        self.assertIn('"minLength": 3', str(column_profile))
 
         self.assertEqual(column_profile.completeness, 1.0)
         self.assertEqual(column_profile.approximateNumDistinctValues, 3)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,16 +1,24 @@
 # -*- coding: utf-8 -*-
 import unittest
 from pyspark.sql import Row
-from pydeequ.profiles import ColumnProfilerRunBuilder, ColumnProfilerRunner, DistributionValue, StringColumnProfile
+from pydeequ.profiles import (
+    ColumnProfilerRunBuilder,
+    ColumnProfilerRunner,
+    DistributionValue,
+    StringColumnProfile,
+)
 from pydeequ.analyzers import KLLParameters, DataTypeInstances
 from tests.conftest import setup_pyspark
+
 
 class TestProfiles(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.spark = setup_pyspark().appName("test-profiles-local").getOrCreate()
         cls.sc = cls.spark.sparkContext
-        cls.df = cls.sc.parallelize([Row(a="foo", b=1, c=5), Row(a="bar", b=2, c=6), Row(a="baz", b=3, c=None)]).toDF()
+        cls.df = cls.sc.parallelize(
+            [Row(a="foo", b=1, c=5), Row(a="bar", b=2, c=6), Row(a="baz", b=3, c=None)]
+        ).toDF()
 
     @classmethod
     def tearDownClass(cls):
@@ -18,10 +26,18 @@ class TestProfiles(unittest.TestCase):
         cls.spark.stop()
 
     def test_setPredefinedTypes(self):
-        result = ColumnProfilerRunner(self.spark) \
-            .onData(self.df) \
-            .setPredefinedTypes({'a': DataTypeInstances.Unknown, 'b': DataTypeInstances.String, 'c': DataTypeInstances.Fractional}) \
+        result = (
+            ColumnProfilerRunner(self.spark)
+            .onData(self.df)
+            .setPredefinedTypes(
+                {
+                    "a": DataTypeInstances.Unknown,
+                    "b": DataTypeInstances.String,
+                    "c": DataTypeInstances.Fractional,
+                }
+            )
             .run()
+        )
         print(result)
         for col, profile in result.profiles.items():
             print("Profiles:", profile)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -92,7 +92,14 @@ class TestProfiles(unittest.TestCase):
         self.assertEqual(result.numRecords, 3)
 
     def test_StringColumnProfile(self):
-        df = self.sc.parallelize([Row(a="ant"), Row(a="bee"), Row(a="bee"), Row(a="cricket")]).toDF()
+        df = self.sc.parallelize(
+            [
+                Row(a="ant", b="dragonfly"),
+                Row(a="bee", b="earwig"),
+                Row(a="bee", b=None),
+                Row(a="cricket", b=None),
+            ]
+        ).toDF()
         result = ColumnProfilerRunner(self.spark).onData(df).run()
         column_profile = result.profiles["a"]
         self.assertIsInstance(column_profile, StringColumnProfile)
@@ -116,6 +123,13 @@ class TestProfiles(unittest.TestCase):
             self.assertEqual(actual.value, expected.value)
             self.assertEqual(actual.count, expected.count)
             self.assertAlmostEqual(actual.ratio, expected.ratio)
+
+        column_profile = result.profiles["b"]
+        self.assertEqual(column_profile.completeness, 0.5)
+        self.assertEqual(column_profile.approximateNumDistinctValues, 2)
+        self.assertEqual(column_profile.typeCounts["String"], 2)
+        self.assertEqual(column_profile.minLength, 0)
+        self.assertEqual(column_profile.maxLength, 9)
 
 
 if __name__ == "__main__":

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -81,43 +81,7 @@ class TestProfiles(unittest.TestCase):
         self.assertIsInstance(column_profile, StringColumnProfile)
         self.assertEqual(column_profile.minLength, 3)
         self.assertEqual(column_profile.maxLength, 4)
-        self.assertEqual(
-            str(column_profile),
-            (
-                'StringProfiles for column: a: {\n'
-                '    "completeness": 1.0,\n'
-                '    "approximateNumDistinctValues": 3,\n'
-                '    "dataType": "String",\n'
-                '    "isDataTypeInferred": false,\n'
-                '    "typeCounts": {\n'
-                '        "Boolean": 0,\n'
-                '        "Fractional": 0,\n'
-                '        "Integral": 0,\n'
-                '        "Unknown": 0,\n'
-                '        "String": 3\n'
-                '    },\n'
-                '    "histogram": [\n'
-                '        [\n'
-                '            "bazz",\n'
-                '            1,\n'
-                '            0.3333333333333333\n'
-                '        ],\n'
-                '        [\n'
-                '            "foo",\n'
-                '            1,\n'
-                '            0.3333333333333333\n'
-                '        ],\n'
-                '        [\n'
-                '            "bar",\n'
-                '            1,\n'
-                '            0.3333333333333333\n'
-                '        ]\n'
-                '    ],\n'
-                '    "minLength": 3,\n'
-                '    "maxLength": 4\n'
-                '}'
-            )
-        )
+        self.assertEqual(str(column_profile)[0:29], "StringProfiles for column: a:")
 
         self.assertEqual(column_profile.completeness, 1.0)
         self.assertEqual(column_profile.approximateNumDistinctValues, 3)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -96,7 +96,7 @@ class TestProfiles(unittest.TestCase):
         for actual, expected in zip(actual_histogram, expected_histogram):
             self.assertEqual(actual.value, expected.value)
             self.assertEqual(actual.count, expected.count)
-            self.assertAlmostEquals(actual.ratio, expected.ratio)
+            self.assertAlmostEqual(actual.ratio, expected.ratio)
 
 
 if __name__ == "__main__":

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 from pyspark.sql import Row
-from pydeequ.analyzers import KLLParameters
-from pydeequ.profiles import ColumnProfilerRunBuilder, ColumnProfilerRunner
+from pydeequ.profiles import ColumnProfilerRunBuilder, ColumnProfilerRunner, DistributionValue, StringColumnProfile
 from pydeequ.analyzers import KLLParameters, DataTypeInstances
 from tests.conftest import setup_pyspark
 
@@ -11,7 +10,7 @@ class TestProfiles(unittest.TestCase):
     def setUpClass(cls):
         cls.spark = setup_pyspark().appName("test-profiles-local").getOrCreate()
         cls.sc = cls.spark.sparkContext
-        cls.df = cls.sc.parallelize([Row(a="foo", b=1, c=5), Row(a="bar", b=2, c=6), Row(a="baz", b=3, c=None)]).toDF()
+        cls.df = cls.sc.parallelize([Row(a="foo", b=1, c=5), Row(a="bar", b=2, c=6), Row(a="bazz", b=3, c=None)]).toDF()
 
     @classmethod
     def tearDownClass(cls):
@@ -75,6 +74,26 @@ class TestProfiles(unittest.TestCase):
     def test_profile_numRecords(self):
         result = ColumnProfilerRunner(self.spark).onData(self.df).run()
         self.assertEqual(result.numRecords, 3)
+
+    def test_StringColumnProfile(self):
+        result = ColumnProfilerRunner(self.spark).onData(self.df).run()
+        column_profile = result.profiles["a"]
+        self.assertIsInstance(column_profile, StringColumnProfile)
+        self.assertEqual(column_profile.minLength, 3)
+        self.assertEqual(column_profile.maxLength, 4)
+
+        self.assertEqual(column_profile.completeness, 1.0)
+        self.assertEqual(column_profile.approximateNumDistinctValues, 3)
+        self.assertEqual(column_profile.typeCounts["String"], 3)
+        self.assertEqual(column_profile.isDataTypeInferred, False)
+        self.assertListEqual(
+            sorted(column_profile.histogram),
+            [
+                DistributionValue("bar", 1, 1/3),
+                DistributionValue("bazz", 1, 1/3),
+                DistributionValue("foo", 1, 1/3),
+            ]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -10,7 +10,7 @@ class TestProfiles(unittest.TestCase):
     def setUpClass(cls):
         cls.spark = setup_pyspark().appName("test-profiles-local").getOrCreate()
         cls.sc = cls.spark.sparkContext
-        cls.df = cls.sc.parallelize([Row(a="foo", b=1, c=5), Row(a="bar", b=2, c=6), Row(a="bazz", b=3, c=None)]).toDF()
+        cls.df = cls.sc.parallelize([Row(a="foo", b=1, c=5), Row(a="bar", b=2, c=6), Row(a="baz", b=3, c=None)]).toDF()
 
     @classmethod
     def tearDownClass(cls):
@@ -76,24 +76,25 @@ class TestProfiles(unittest.TestCase):
         self.assertEqual(result.numRecords, 3)
 
     def test_StringColumnProfile(self):
-        result = ColumnProfilerRunner(self.spark).onData(self.df).run()
+        df = self.sc.parallelize([Row(a="ant"), Row(a="bee"), Row(a="bee"), Row(a="cricket")]).toDF()
+        result = ColumnProfilerRunner(self.spark).onData(df).run()
         column_profile = result.profiles["a"]
         self.assertIsInstance(column_profile, StringColumnProfile)
         self.assertEqual(column_profile.minLength, 3)
-        self.assertEqual(column_profile.maxLength, 4)
+        self.assertEqual(column_profile.maxLength, 7)
         self.assertEqual(str(column_profile)[0:29], "StringProfiles for column: a:")
         self.assertIn('"minLength": 3', str(column_profile))
 
-        self.assertEqual(column_profile.completeness, 1.0)
+        self.assertEqual(column_profile.completeness, 1)
         self.assertEqual(column_profile.approximateNumDistinctValues, 3)
-        self.assertEqual(column_profile.typeCounts["String"], 3)
+        self.assertEqual(column_profile.typeCounts["String"], 4)
         self.assertEqual(column_profile.isDataTypeInferred, False)
         actual_histogram = sorted(column_profile.histogram, key=lambda x: x.value)
         self.assertEqual(len(actual_histogram), 3)
         expected_histogram = [
-            DistributionValue("bar", 1, 1 / 3),
-            DistributionValue("bazz", 1, 1 / 3),
-            DistributionValue("foo", 1, 1 / 3),
+            DistributionValue("ant", 1, 0.25),
+            DistributionValue("bee", 2, 0.5),
+            DistributionValue("cricket", 1, 0.25),
         ]
         for actual, expected in zip(actual_histogram, expected_histogram):
             self.assertEqual(actual.value, expected.value)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -81,6 +81,43 @@ class TestProfiles(unittest.TestCase):
         self.assertIsInstance(column_profile, StringColumnProfile)
         self.assertEqual(column_profile.minLength, 3)
         self.assertEqual(column_profile.maxLength, 4)
+        self.assertEqual(
+            str(column_profile),
+            (
+                'StringProfiles for column: a: {\n'
+                '    "completeness": 1.0,\n'
+                '    "approximateNumDistinctValues": 3,\n'
+                '    "dataType": "String",\n'
+                '    "isDataTypeInferred": false,\n'
+                '    "typeCounts": {\n'
+                '        "Boolean": 0,\n'
+                '        "Fractional": 0,\n'
+                '        "Integral": 0,\n'
+                '        "Unknown": 0,\n'
+                '        "String": 3\n'
+                '    },\n'
+                '    "histogram": [\n'
+                '        [\n'
+                '            "bazz",\n'
+                '            1,\n'
+                '            0.3333333333333333\n'
+                '        ],\n'
+                '        [\n'
+                '            "foo",\n'
+                '            1,\n'
+                '            0.3333333333333333\n'
+                '        ],\n'
+                '        [\n'
+                '            "bar",\n'
+                '            1,\n'
+                '            0.3333333333333333\n'
+                '        ]\n'
+                '    ],\n'
+                '    "minLength": 3,\n'
+                '    "maxLength": 4\n'
+                '}'
+            )
+        )
 
         self.assertEqual(column_profile.completeness, 1.0)
         self.assertEqual(column_profile.approximateNumDistinctValues, 3)


### PR DESCRIPTION
*Issue #, if available:*
#247 

*Description of changes:*
Adding `StringColumnProfile` as a subclass of `StandardColumnProfile` to expose the additional results available for string columns in Scala - `minLength` and `maxLength`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
