### PR TITLE
Remove expired Slack invite from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ There are 4 main components of Deequ, and they are:
 - With PyDeequ v0.1.8+, we now officially support Spark3 ! Just make sure you have an environment variable `SPARK_VERSION` to specify your Spark version! 
 - We've release a blogpost on integrating PyDeequ onto AWS leveraging services such as AWS Glue, Athena, and SageMaker! Check it out: [Monitor data quality in your data lake using PyDeequ and AWS Glue](https://aws.amazon.com/blogs/big-data/monitor-data-quality-in-your-data-lake-using-pydeequ-and-aws-glue/).
 - Check out the [PyDeequ Release Announcement Blogpost](https://aws.amazon.com/blogs/big-data/testing-data-quality-at-scale-with-pydeequ/) with a tutorial walkthrough the Amazon Reviews dataset!
-- Join the PyDeequ community on [PyDeequ Slack](https://join.slack.com/t/pydeequ/shared_invite/zt-te6bntpu-yaqPy7bhiN8Lu0NxpZs47Q) to chat with the devs!
 
 ## Quickstart
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #78
Fixes #159
Fixes #228

*Description of changes:*

Removes the expired PyDeequ Slack invite from the README announcements. The linked invite is no longer active, and a maintainer noted that the reference should be removed for now.

Validation:
- `git diff --check`
- Searched for remaining Slack invite references
- Tests not run locally (documentation-only change)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.