### PR TITLE
Use package metadata for pydeequ version

### DIFF
--- a/pydeequ/__init__.py
+++ b/pydeequ/__init__.py
@@ -12,7 +12,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Placeholder docstrings"""
-__version__ = "1.2.0"
+from importlib.metadata import version
+
+__version__ = version("pydeequ")
 
 from pyspark.sql import SparkSession
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from importlib.metadata import version
+
+import pydeequ
+
+
+def test_package_version_is_exposed():
+    assert pydeequ.__version__ == version("pydeequ")


### PR DESCRIPTION
*Issue #, if available:*
Closes #239

*Description of changes:*
- derive `pydeequ.__version__` from installed package metadata instead of a stale hardcoded string
- add a regression test that compares `pydeequ.__version__` with `importlib.metadata.version(pydeequ)`

Validation:
- `git diff --check HEAD~1..HEAD`
- static review of `pydeequ/__init__.py` and `tests/test_version.py`
- Tests not run locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.