### PR TITLE
refactor: standardize bot identity to shadow (match deequ)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -55,6 +55,21 @@ jobs:
               return;
             }
 
+            // Condition 0: never auto-approve a PR that changes the bot's own
+            // guardrails (workflows or engine config) — that lets a PR weaken
+            // the approval gate and be approved by the very gate it edits.
+            // Require a human for these.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: prNumber, per_page: 100
+            });
+            const guarded = files.find(f =>
+              f.filename.startsWith('.github/') || f.filename === '.shadow.yml'
+            );
+            if (guarded) {
+              core.info(`PR touches guarded path ${guarded.filename} — requires human review, skipping`);
+              return;
+            }
+
             // Condition 1: CI must have passed for this SHA
             const {data: workflowRuns} = await github.rest.actions.listWorkflowRunsForRepo({
               owner, repo, head_sha: sha, status: 'completed'

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,7 +2,7 @@ name: Auto-Approve Clean PRs
 
 on:
   workflow_run:
-    workflows: [".github/workflows/base.yml", "PyDeequ Bot"]
+    workflows: [".github/workflows/base.yml", "Shadow"]
     types: [completed]
 
 permissions:
@@ -72,7 +72,7 @@ jobs:
               owner, repo, pull_number: prNumber
             });
 
-            const CLEAN_MARKER = '<!-- deequ-bot:clean -->';
+            const CLEAN_MARKER = '<!-- shadow:clean -->';
 
             const latestBot = reviews
               .filter(r => r.user.login === 'github-actions[bot]')

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -1,4 +1,4 @@
-name: PyDeequ Bot   # load-bearing: auto-approve.yml keys on this exact name
+name: Shadow   # load-bearing: auto-approve.yml keys on this exact name
 # To upgrade the engine, bump the SHA in BOTH `uses:` and `shadow_ref` below
 # (GitHub forbids expressions in `uses:`, so they can't share a variable).
 

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -54,6 +54,7 @@ jobs:
       KB_S3_BUCKET: ${{ secrets.KB_S3_BUCKET }}
       KB_S3_KEY: ${{ secrets.KB_S3_KEY }}
       BEDROCK_MODEL_ID: ${{ secrets.BEDROCK_MODEL_ID }}
+      # Repo variables (not secrets); empty falls back to engine defaults.
       BEDROCK_REPORTER_MODEL_ID: ${{ vars.BEDROCK_REPORTER_MODEL_ID }}
       BEDROCK_CRITIC_MODEL_ID: ${{ vars.BEDROCK_CRITIC_MODEL_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.shadow.yml
+++ b/.shadow.yml
@@ -7,7 +7,7 @@ codebase:
   language: python
 
 bot:
-  name: deequ-bot   # not pydeequ-bot: must render the <!-- deequ-bot:clean --> marker auto-approve.yml greps for
+  name: shadow   # renders the <!-- shadow:clean --> marker auto-approve.yml greps for
   attribution: "Reviewed by Shadow · github.com/sudsali/shadow"
   escalate_label: needs-human
   max_replies: 2


### PR DESCRIPTION
## Summary

Standardizes the bot's user-facing identity from `deequ-bot` to `shadow`, matching [awslabs/deequ](https://github.com/awslabs/deequ) and [awslabs/dqdl](https://github.com/awslabs/dqdl). The [Shadow engine migration](https://github.com/awslabs/python-deequ/pull/277) kept the legacy `deequ-bot` name to avoid touching `auto-approve.yml`; this follow-up aligns the name with the shared engine's home project so all three repos are uniform.

## What Changes

Four references move **in lockstep** — changing any one alone breaks the clean-marker match and silently disables auto-approval:

- `.shadow.yml` — `bot.name: deequ-bot` → `shadow` (the engine renders `<!-- {bot.name}:clean -->`)
- `.github/workflows/auto-approve.yml` — `CLEAN_MARKER` → `<!-- shadow:clean -->` and the `workflows[]` trigger entry → `"Shadow"`
- `.github/workflows/issue-bot.yml` — workflow `name:` → `Shadow`

`prompt_sm_prefix: pydeequ-bot` is unchanged — that's the Secrets Manager namespace where this repo's prompts live, not the bot's display identity.

## Behavior

Clean reviews now carry `<!-- shadow:clean -->`; the bot posts as "Shadow" and the footer already reads "Reviewed by Shadow". No functional change beyond the rename.

> Note: a PR the bot reviewed *before* this merges carries the old `<!-- deequ-bot:clean -->` marker; auto-approve recognizes it again after the bot re-reviews (any new commit). Only affects in-flight PRs.

## Rollback

Revert this PR — the four references return to `deequ-bot` / `PyDeequ Bot` in lockstep.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Also: harden auto-approve
Adds a Condition-0 guard so the bot never auto-approves a PR that touches `.github/**` or `.shadow.yml` (its own guardrails). This PR itself touches those paths, so it correctly requires human approval.
