### PR TITLE
ci: bump Shadow engine to v1.7

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -1,5 +1,5 @@
 name: Shadow   # load-bearing: auto-approve.yml keys on this exact name
-# To upgrade the engine, bump the SHA in BOTH `uses:` and `shadow_ref` below
+# To upgrade the engine, bump the ref in BOTH `uses:` and `shadow_ref` below
 # (GitHub forbids expressions in `uses:`, so they can't share a variable).
 
 on:
@@ -40,11 +40,11 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.actor != 'github-actions[bot]' &&
        (github.event.issue.pull_request == null || github.event_name == 'pull_request_target'))
-    uses: sudsali/shadow/.github/workflows/shadow-review.yml@54ec94e0ca8c90d9b58ff95a2a06b175a115784e
+    uses: sudsali/shadow/.github/workflows/shadow-review.yml@v1.7
     with:
       pr_number: ${{ inputs.issue_number }}
       dry_run: ${{ inputs.dry_run && 'true' || 'false' }}
-      shadow_ref: 54ec94e0ca8c90d9b58ff95a2a06b175a115784e
+      shadow_ref: v1.7
       aws_region: us-east-1
       prompt_sm_prefix: pydeequ-bot
     secrets:

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -40,11 +40,11 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.actor != 'github-actions[bot]' &&
        (github.event.issue.pull_request == null || github.event_name == 'pull_request_target'))
-    uses: sudsali/shadow/.github/workflows/shadow-review.yml@v1.7
+    uses: sudsali/shadow/.github/workflows/shadow-review.yml@ed31ed7e30ef81be82d7b8b756b626f876036d73 # v1.7
     with:
       pr_number: ${{ inputs.issue_number }}
       dry_run: ${{ inputs.dry_run && 'true' || 'false' }}
-      shadow_ref: v1.7
+      shadow_ref: ed31ed7e30ef81be82d7b8b756b626f876036d73 # v1.7
       aws_region: us-east-1
       prompt_sm_prefix: pydeequ-bot
     secrets:


### PR DESCRIPTION
## Summary

Re-pin the Shadow PR-review engine from `54ec94e` (v1.6) to **v1.7**, following the [dqdl canary](https://github.com/awslabs/dqdl/pull/41) (merged and soaking).

v1.7 adds configurable `allowed_labels` and a `bot.name`-branded rate-limit label. **No `.shadow.yml` change here**, so those features stay dormant — behavior is unchanged; this only moves the engine version.

## Changes

- `.github/workflows/issue-bot.yml` — bump `uses:` and `shadow_ref` from the `54ec94e` SHA to the `v1.7` tag (both must move together; GitHub forbids expressions in `uses:`).

## Safety

- **OIDC unaffected:** the bot IAM role's trust is scoped to `repo:<this-repo>:*`, not pinned to a workflow ref, so the engine-ref change doesn't affect role assumption.
- **Rollback:** revert to re-pin `54ec94e`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
